### PR TITLE
Add support for broker suffixed symbols

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: pip
 
       - name: Install and test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/mt5connect/providers.py
+++ b/mt5connect/providers.py
@@ -93,11 +93,12 @@ class MT5InstrumentProvider(InstrumentProvider):
         self._conn.ensure_connected()
         self._failed_symbols.clear()
 
-        # Apply symbol filter if provided
-        # Use `is not None` (not just truthy) so an empty list [] means "load nothing"
-        symbol_filter: list[str] | None = None
+        # Keep requested symbols in broker casing; filter resolution happens after
+        # symbols_get() so exact broker names can win before alias fallback.
+        # Use `is not None` (not just truthy) so an empty list [] means "load nothing".
+        requested_symbols: list[str] | None = None
         if filters is not None and "symbols" in filters:
-            symbol_filter = [s.upper().strip() for s in filters["symbols"]]
+            requested_symbols = [s.strip() for s in filters["symbols"]]
 
         # Get all available symbols from broker
         all_symbols = mt5.symbols_get()
@@ -113,6 +114,31 @@ class MT5InstrumentProvider(InstrumentProvider):
         filtered = 0
 
         logger.info(f"MT5InstrumentProvider: loading {total} symbols from broker")
+
+        # Resolve the user filter to actual broker symbols while preserving the
+        # broker-provided symbol strings that parse_symbol_info() will register.
+        symbol_filter: set[str] | None = None
+        if requested_symbols is not None:
+            available_symbols = [sym_info.name for sym_info in all_symbols]
+            available_symbol_set = set(available_symbols)
+            symbol_filter = set()
+
+            # First pass prefers exact broker names such as EURUSDm over any
+            # case-insensitive alias that may also exist.
+            fallback_symbols: list[str] = []
+            for requested in requested_symbols:
+                if requested in available_symbol_set:
+                    symbol_filter.add(requested)
+                else:
+                    fallback_symbols.append(requested)
+
+            # Second pass keeps existing convenience behavior for callers who
+            # pass lowercase or mixed-case symbols.
+            for requested in fallback_symbols:
+                requested_upper = requested.upper()
+                for available in available_symbols:
+                    if available.upper() == requested_upper:
+                        symbol_filter.add(available)
 
         for sym_info in all_symbols:
             symbol = sym_info.name
@@ -265,11 +291,29 @@ class MT5InstrumentProvider(InstrumentProvider):
             Symbol name (e.g. "EURUSD"). Case-insensitive.
         """
         from mt5connect.constants import MT5_VENUE
-        instrument_id = InstrumentId(
-            Symbol(symbol.upper().strip()),
-            MT5_VENUE,
-        )
-        return self.find(instrument_id)
+
+        # Empty input cannot form a Nautilus Symbol and should behave as a miss.
+        raw = symbol.strip()
+        if not raw:
+            return None
+
+        # Prefer exact broker symbols before uppercase fallback to preserve
+        # suffixes like EURUSDm that are already loaded under their real ID.
+        candidates = [raw, raw.upper()]
+        for candidate in dict.fromkeys(candidates):
+            instrument_id = InstrumentId(Symbol(candidate), MT5_VENUE)
+            instrument = self.find(instrument_id)
+            if instrument is not None:
+                return instrument
+
+        # Final scan supports practical case-insensitive aliases for loaded
+        # symbols whose broker casing does not match the request exactly.
+        raw_upper = raw.upper()
+        for instrument in self.list_all():
+            if instrument.id.symbol.value.upper() == raw_upper:
+                return instrument
+
+        return None
 
     @property
     def loaded_symbols(self) -> list[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.3.0"
 description = "NautilusTrader adapter for MetaTrader 5 — live trading and backtesting on any MT5 broker"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 authors = [
     { name = "mt5-connector contributors" },
 ]

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -86,6 +86,8 @@ def make_symbol_info(
 
 # Pre-built symbol infos for standard test symbols
 EURUSD_INFO  = make_symbol_info("EURUSD",  digits=5, currency_base="EUR",  currency_profit="USD")
+# Broker-suffixed fixture verifies lowercase suffixes are not uppercased away.
+EURUSDM_INFO = make_symbol_info("EURUSDm", digits=5, currency_base="EUR",  currency_profit="USD")
 GBPUSD_INFO  = make_symbol_info("GBPUSD",  digits=5, currency_base="GBP",  currency_profit="USD")
 XAUUSD_INFO  = make_symbol_info("XAUUSD",  digits=2, currency_base="XAU",  currency_profit="USD", trade_contract_size=100.0,  margin_initial=1.0)
 BTCUSD_INFO  = make_symbol_info("BTCUSD",  digits=2, currency_base="BTC",  currency_profit="USD", trade_contract_size=1.0,    margin_initial=1.0)
@@ -96,6 +98,8 @@ ALL_SYMBOLS_INFO = [EURUSD_INFO, GBPUSD_INFO, XAUUSD_INFO, BTCUSD_INFO, US500_IN
 # Map symbol name → info for mock lookup
 SYMBOL_INFO_MAP = {
     "EURUSD": EURUSD_INFO,
+    # The suffixed key must stay exact because mt5.symbol_info() is exact-name based.
+    "EURUSDm": EURUSDM_INFO,
     "GBPUSD": GBPUSD_INFO,
     "XAUUSD": XAUUSD_INFO,
     "BTCUSD": BTCUSD_INFO,
@@ -292,6 +296,34 @@ class TestLoadAllAsyncFilter:
 
         assert provider.count == 1
         assert "EURUSD" in provider.loaded_symbols
+
+    @pytest.mark.asyncio
+    async def test_filter_preserves_exact_suffixed_symbol(self, provider):
+        # Exact filter names should load the broker symbol with its original case.
+        with patch("mt5connect.providers.mt5") as mock_mt5:
+            mock_mt5.symbols_get.return_value   = [EURUSDM_INFO, EURUSD_INFO]
+            mock_mt5.symbol_select.return_value = True
+            mock_mt5.symbol_info.side_effect    = lambda s: SYMBOL_INFO_MAP.get(s)
+            mock_mt5.last_error.return_value    = (0, "No error")
+
+            await provider.load_all_async(filters={"symbols": ["EURUSDm"]})
+
+        assert provider.count == 1
+        assert provider.loaded_symbols == ["EURUSDm"]
+
+    @pytest.mark.asyncio
+    async def test_filter_lowercase_matches_suffixed_symbol(self, provider):
+        # Lowercase filters remain supported through case-insensitive fallback.
+        with patch("mt5connect.providers.mt5") as mock_mt5:
+            mock_mt5.symbols_get.return_value   = [EURUSDM_INFO, GBPUSD_INFO]
+            mock_mt5.symbol_select.return_value = True
+            mock_mt5.symbol_info.side_effect    = lambda s: SYMBOL_INFO_MAP.get(s)
+            mock_mt5.last_error.return_value    = (0, "No error")
+
+            await provider.load_all_async(filters={"symbols": ["eurusdm"]})
+
+        assert provider.count == 1
+        assert provider.loaded_symbols == ["EURUSDm"]
 
     @pytest.mark.asyncio
     async def test_no_filter_loads_all(self, provider):
@@ -590,6 +622,17 @@ class TestLoadSymbol:
 
         assert "EURUSD" in provider.loaded_symbols
 
+    def test_load_suffixed_symbol_preserves_broker_case(self, provider):
+        # Direct symbol loading should store the parsed broker name unchanged.
+        with patch("mt5connect.providers.mt5") as mock_mt5:
+            mock_mt5.symbol_select.return_value = True
+            mock_mt5.symbol_info.return_value   = EURUSDM_INFO
+            mock_mt5.last_error.return_value    = (0, "No error")
+
+            provider.load_symbol("EURUSDm")
+
+        assert provider.loaded_symbols == ["EURUSDm"]
+
     def test_load_xauusd_returns_cfd(self, provider):
         with patch("mt5connect.providers.mt5") as mock_mt5:
             mock_mt5.symbol_select.return_value = True
@@ -729,6 +772,26 @@ class TestGetInstrument:
 
         assert provider.get_instrument("eurusd") is not None
         assert provider.get_instrument("EurUsd") is not None
+
+    def test_exact_suffixed_symbol_lookup(self, provider):
+        # Exact lookup should find the instrument without changing its symbol ID.
+        with patch("mt5connect.providers.mt5") as mock_mt5:
+            mock_mt5.symbol_select.return_value = True
+            mock_mt5.symbol_info.return_value   = EURUSDM_INFO
+            mock_mt5.last_error.return_value    = (0, "No error")
+            loaded = provider.load_symbol("EURUSDm")
+
+        assert provider.get_instrument("EURUSDm") is loaded
+
+    def test_lowercase_suffixed_symbol_lookup_fallback(self, provider):
+        # Lowercase lookup should still resolve to the exact loaded broker symbol.
+        with patch("mt5connect.providers.mt5") as mock_mt5:
+            mock_mt5.symbol_select.return_value = True
+            mock_mt5.symbol_info.return_value   = EURUSDM_INFO
+            mock_mt5.last_error.return_value    = (0, "No error")
+            loaded = provider.load_symbol("EURUSDm")
+
+        assert provider.get_instrument("eurusdm") is loaded
 
     def test_correct_type_returned(self, provider):
         with patch("mt5connect.providers.mt5") as mock_mt5:


### PR DESCRIPTION

### Objective

Make instrument lookup consistent with the connector's existing exact-symbol
configuration and parser behavior.

### Current Behavior

The connector already preserves exact configured symbols in `MT5Config`.
However, `mt5connect.providers.MT5InstrumentProvider.get_instrument(...)`
builds an `InstrumentId` from `Symbol(symbol.upper().strip())`.

This can fail for broker symbols like `EURUSDm`, because
`parse_symbol_info(...)` preserves the broker-provided symbol as
`EURUSDm.MT5`.

`load_all_async(...)` also uppercases the configured symbol filter before
comparing it to broker symbols, which can filter out exact broker names with
lowercase suffixes.

### Reasoning

MT5 brokers commonly expose suffixed names such as `EURUSDm`, `XAUUSD.a`, or
similar variants. Nautilus strategies, data clients, and execution clients all
depend on stable `InstrumentId` lookup after instruments are loaded. The parser
already preserves broker-provided symbols, but the provider lookup currently
normalizes requested symbols to uppercase. This creates a mismatch where an
instrument can be loaded but not retrieved later by live data or execution
code. Exact-first lookup fixes broker-suffix handling while preserving
case-insensitive convenience for standard uppercase symbols.

### Tests

Add or update `tests/test_providers.py`:

1. `load_symbol("EURUSDm")` stores `EURUSDm` in `loaded_symbols`.
2. `get_instrument("EURUSDm")` returns the exact instrument.
3. `get_instrument("eurusdm")` returns the same instrument through fallback.
4. `load_all_async(filters={"symbols": ["EURUSDm"]})` loads `EURUSDm`.
5. `load_all_async(filters={"symbols": ["eurusdm"]})` loads `EURUSDm`.
6. Existing uppercase symbol tests still pass.

### Acceptance Criteria

- Broker-suffixed symbols can be loaded and retrieved without losing case.
- Existing callers using uppercase symbols continue to work.
- No live MT5 terminal is required for the test suite.

### Python Versions

I've also updated the referenced Python versions to align with current versions of Nautilus Trader that only supports Python 3.12 and Python 3.13.

### Test failures

There are some test failures related to recent changes to `data.py` (not mine) that I didn't address.